### PR TITLE
Enabled latex on ubuntu

### DIFF
--- a/packages/desktop/latex/latex.info
+++ b/packages/desktop/latex/latex.info
@@ -4,7 +4,7 @@
 # LaTeX Info file
 #
 
-export package_support="arch"
+export package_support="arch debian ubuntu"
 
 echo "LaTeX: A markup language"
 


### PR DESCRIPTION
Just tested on 19.04, not sure why it wasn't enabled before