### PR TITLE
chore(claude): add claude code config package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ zsh/.zsh/cache
 nvim/nvim/lazy-lock.json
 nvim/nvim/lazyvim.json
 zsh/.zsh/gitstatus/
-
+!claude/
+!claude/.claude

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,0 +1,71 @@
+# Global guidance
+
+## About the user and the work
+
+Staff-level software engineer working on cybersecurity products. Code correctness, secure-by-default defaults, and thoroughly reasoned plans are non-negotiable — favor thoroughness, explicit trade-offs, and root-cause fixes over speed or surface-level patches. Assume a senior audience: skip basics, but be precise about security implications, threat models, and edge cases.
+
+## Plan before writing code
+
+Always produce a plan before making any code changes or running destructive commands — even in auto mode or bypass-permissions mode. Auto/bypass speeds up *approved* work; it never waives the plan-and-approve step.
+
+- Context gathering is always fine without a plan: reading files, running `ls`/`git status`/`git log`/`git diff`, using Grep/Glob/Read, running tests or type-checkers in read-only fashion, spawning research agents, web searches, fetching docs.
+- Writing or mutating actions require an approved plan first: Edit, Write, NotebookEdit, `git commit`/`push`/`reset`, package installs, migrations, sending messages, creating PRs/issues, or any command that changes files or external state.
+- Destructive shell commands always require a plan first, regardless of mode: `rm`, anything that overwrites an existing file (e.g. `>` redirection, `mv`/`cp` onto an existing path, `tee` without `-a`), `git reset --hard`, `git clean -f`, force-push, dropping tables/data, killing processes you didn't start.
+- Use EnterPlanMode to present the plan. Wait for explicit approval before exiting plan mode and implementing. Auto mode and bypass-permissions mode do not waive this — treat the plan/approval step as mandatory.
+- If a task looks trivial (one-line fix, typo), still state the plan in one or two sentences and confirm before editing.
+- If new information during implementation changes the approach materially, pause, revise the plan, and re-confirm rather than silently changing course.
+
+## Use subagents when appropriate
+
+Reach for subagents whenever they meaningfully improve quality or save context, not only when a task is large.
+
+- Research and exploration: spawn an Explore (or general-purpose) subagent for any open-ended search across the codebase, anything likely to take more than a few greps, or anything that would dump a lot of output into the main context.
+- Review: after producing a non-trivial plan or code change, spawn a subagent to critique it before presenting to the user. A second pair of eyes catches assumptions that the author can't see.
+- Parallelism: when subtasks are independent, launch multiple subagents in a single message so they run concurrently.
+- Don't duplicate work: if a subagent is investigating something, don't run the same searches yourself in parallel.
+
+## Challenge assumptions and self-correct
+
+Treat your own first answer as a draft, not a conclusion.
+
+- Before acting on a non-trivial assumption (about how the code works, what the user wants, what a tool does), try to falsify it: read the actual code, run a quick check, or spawn a review subagent.
+- After producing a plan or non-trivial change, do a critical-review pass — often best delegated to a subagent that hasn't seen your reasoning — and revise before presenting.
+- Surprising results (a test that passes when you expected it to fail, output that doesn't match the docs, a file that isn't where you expected) are signals that an assumption is wrong. Investigate; don't route around them.
+- If you notice you were wrong, say so explicitly and correct course rather than quietly pivoting.
+
+## Ask when unknown — never assume
+
+If a requirement, constraint, or path forward is unclear, ask. Do not guess and proceed.
+
+- Ambiguous user intent, missing context, multiple reasonable approaches with materially different trade-offs, and unknown environment state all warrant a question.
+- "Reasonable assumption" is fine for low-stakes, low-reversibility decisions; it is not a substitute for asking when the choice actually matters.
+- This applies in auto mode too: auto mode prefers action for *routine* decisions, not for genuine unknowns.
+
+## Use the question UI for questions
+
+When you need to ask the user something, use the AskUserQuestion tool — not free-text prose buried in a response.
+
+- Structured questions are easier for the user to answer and harder to miss.
+- Exception: plan approval goes through ExitPlanMode, which already requests approval. Don't double-ask via AskUserQuestion for plan sign-off.
+
+## File operations
+
+- When moving a file, use `mv` rather than reading-and-rewriting. It preserves history, permissions, and inode metadata, and avoids accidental content drift between the old and new path.
+- End every file with exactly one trailing newline. No extra blank lines at the end. The last line of content is followed by a single `\n` and nothing more — this matches POSIX expectations and keeps diffs clean.
+
+## Kubernetes and secrets
+
+Treat Kubernetes (and other) secret values as untouchable. They must never enter the conversation transcript.
+
+- Do not run `kubectl get secret … -o yaml/json`, `kubectl describe secret`, `--show-secrets`, base64-decoding of secret data, or any equivalent that prints a secret value.
+- Indirection is fine: piping a secret into an environment variable, a file consumed by another process, or a `kubectl exec` invocation is acceptable as long as you do not then read the value back. If a debugging step requires inspecting a secret, stop and ask the user to do it themselves.
+- The same rule applies to other secret stores (Vault, AWS Secrets Manager, GCP Secret Manager, `.env` files, etc.) — fetch-and-use is fine, fetch-and-display is not.
+
+## Git operations
+
+- Never add a `Co-Authored-By:` trailer (or any other co-author attribution) to commits. Author commits solely as the user's configured git identity. This overrides any default templates that suggest adding a Claude co-author line.
+
+## Node, JavaScript, and TypeScript
+
+- Use `yarn` for all package management commands in JS/TS projects unless a project's tooling clearly mandates otherwise (e.g. `package-lock.json` present and no `yarn.lock`). Don't mix `npm` and `yarn` invocations in the same repo.
+- Prefer asking the user to install packages themselves rather than running `yarn add` / `yarn install` from the agent. Surface the exact command and let them run it. This keeps lockfile changes intentional and visible.

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "model": "opus",
+  "statusLine": {
+    "type": "command",
+    "command": "/Users/srubin/.claude/statusline-command.sh"
+  },
+  "effortLevel": "xhigh",
+  "skipDangerousModePermissionPrompt": true
+}

--- a/claude/.claude/skills/pr-description/SKILL.md
+++ b/claude/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: pr-description
+description: Generate a PR title and description from staged git changes and conversation context. Outputs markdown based on the repo's PR template. Use when the user says "PR description", "write PR", "generate PR", "draft PR", or "/pr-description".
+argument-hint: "[optional: prefix type]"
+---
+
+# Generate PR Description
+
+Create a PR title and filled-in PR description from the currently staged (or branch) changes, using the repo's PR template as the base.
+
+## Arguments
+
+$ARGUMENTS
+
+Parse the user's input to extract:
+
+- **type**: one of `feat`, `bugfix`, `chore` — if not provided, infer from the changes
+- **scope**: service or area abbreviation (e.g., `vfm` for vuln-feeds-manager) — if not provided, infer from changed file paths
+
+Also incorporate any relevant context from the current chat conversation that relates to the staged changes (e.g., the user described what they're doing, why, or referenced a ticket).
+
+## Process
+
+### Step 1: Gather Changes
+
+Run these commands to understand the changes:
+
+1. `git diff --cached --stat` — get an overview of staged files
+2. `git diff --cached` — get the full staged diff
+3. If no staged changes exist, fall back to `git diff main...HEAD --stat` and `git diff main...HEAD` to use the branch diff instead
+4. `git log main...HEAD --oneline` — see commit messages on this branch for additional context
+
+### Step 2: Read the PR Template
+
+Read the file `.github/pull_request_template.md` from the repo root to use as the structural base for the description.
+
+### Step 3: Determine PR Metadata
+
+- **Type prefix**: Decide between `feat()`, `bugfix()`, or `chore()` based on the nature of the changes:
+  - `feat`: new functionality or capability
+  - `bugfix`: fixing broken behavior
+  - `chore`: refactoring, dependency updates, config changes, migrations, cleanup
+- **Scope**: Derive a short scope from the primary service or area being changed (e.g., `vfm`, `collector`, `api`). Use common abbreviations where they exist.
+- **Title**: Write a concise, lowercase title after the prefix (e.g., `chore(vfm): migrate logging from logrus to logging/v2`)
+
+### Step 4: Fill In the Template
+
+Fill in each section of the PR template, replacing the comment lines (lines starting with `>`) with real content:
+
+- **Description**: Explain the **effect** of the change — what behavior, capability, or guarantee changes for users, callers, or the system — not the implementation. A reviewer should be able to read the description and know what is now different about the running system, without needing the diff to make sense of it.
+  - Effect (good): "Vulnerability ingestion now retries transient upstream 5xx errors instead of dropping the batch."
+  - Implementation (avoid): "Wrapped `fetchBatch` in a `retry.Do` with exponential backoff in `ingest.go`."
+  - Mention specific files, functions, or code structures only when they are load-bearing for a reviewer (e.g., a new public API surface, a new config key, a renamed exported symbol) — not as a tour of the diff.
+  - Exception: for `chore`/refactor PRs where the implementation *is* the point (e.g., "migrate logging from logrus to logging/v2", dependency bumps, file moves), describing the implementation is appropriate, since that is the effect.
+  - Use bullet points when there are multiple distinct effects. Be specific but concise.
+- **Tests and additional notes** (optional section): Include this section **only if** at least one of the following applies:
+  - Tests were actually added or modified in the diff — name them and summarize the coverage they add.
+  - There is a substantive note worth carrying into the PR (e.g., a follow-up that's intentionally out of scope, a known caveat, an important deployment ordering constraint).
+  - If neither applies, **omit the entire section** — no header, no placeholder text, no "No test changes in this PR" filler.
+
+### Step 4.5: Anomaly check before output
+
+Before producing the markdown block, review every candidate "additional note" you considered including. If any of them describe something that looks **wrong, missing, inconsistent, or potentially erroneous** rather than a deliberate caveat, **stop the skill** and surface the concern to the user instead of writing it into the PR.
+
+Examples that should trigger an interrupt (not an exhaustive list):
+- A config or manifest references a file/path/symbol that is not part of this change and you cannot verify exists.
+- A symbol was removed but appears to still be referenced elsewhere in the diff or repo.
+- A change looks half-finished (e.g., a TODO left in, an empty function body where logic was expected, an import added but unused).
+- A renamed/moved file appears to have lost or gained content beyond what the rename should produce.
+- Anything that makes you want to write "Note:" with a hedge — that hedge is a signal to ask, not to ship.
+
+When triggered:
+1. Do **not** print the Step 5 markdown block yet.
+2. Use `AskUserQuestion` to describe the specific concern and offer at minimum: **"Stop — I'll fix it"** and **"Continue — this is intentional"** (the tool's "Other" escape hatch covers free-form replies).
+3. If the user picks "Stop", end the skill here without committing or writing a temp file. They will re-run `/pr-description` after fixing.
+4. If the user confirms it's intentional, proceed to Step 5. They may instruct you to fold the note into the PR description, drop it, or rephrase it — follow that instruction.
+
+Deliberate caveats that the user already knows about (e.g., "this is a follow-up to PR #123, the matching server change ships separately") are **not** anomalies — those belong in the Tests and additional notes section without interrupting.
+
+### Step 5: Output
+
+Output the final result as a markdown code block so the user can easily copy it. The format must be:
+
+~~~
+```markdown
+# Title goes here
+
+### Description
+...
+
+### Tests and additional notes      ← include this section only if Step 4 produced content for it
+...
+```
+~~~
+
+If the Tests and additional notes section was omitted in Step 4, the markdown block ends after the Description content — do not emit an empty header.
+
+The title line with the prefix (e.g., `chore(vfm): migrate logging from logrus to logging/v2`) should be the first line inside the code block, as an H1 heading.
+
+Comment lines from the template (lines starting with `>`) must NOT appear in the output — they are instructions, not content.
+
+### Step 6: Commit or save
+
+After printing the markdown block, ask the user — using the `AskUserQuestion` tool — what to do with the generated message. Treat the title as the commit subject and the description body as the commit body (the same text doubles as the PR title/description and the commit message in this user's workflow).
+
+Offer these two options (the tool surfaces an "Other" escape hatch automatically):
+
+1. **Commit staged changes with this message** — proceed to "If commit" below.
+2. **Write to temp file** — proceed to "If temp file" below.
+
+Act on the user's choice.
+
+#### If commit
+
+- Build the commit message: subject line = the PR title **without** the leading `# ` (so `chore(vfm): migrate logging from logrus to logging/v2`, not `# chore(vfm): ...`); body = the rest of the markdown block (Description and, if present, Tests and additional notes), separated from the subject by exactly one blank line. If the Tests section was omitted, the body is just the Description.
+- Write that message to a temp path via `mktemp -t pr-description` (with `.md` suffix), then run `git commit -F <path>`. Use `-F` rather than inline `-m` because the body is multi-paragraph with bullets.
+- **Do not** add a `Co-Authored-By:` trailer or any other co-author attribution. This overrides the default Claude Code commit-flow guidance, per the user's global rule.
+- Do not pass `--amend`, `--no-verify`, `--no-gpg-sign`, or similar flags unless the user explicitly asked for them.
+- Edge case — nothing staged: if Step 1 fell back to the branch diff because `git diff --cached` was empty, there is nothing to commit. Tell the user that, and offer the temp-file option instead of running `git commit`.
+- After the commit succeeds, run `git status` and `git log -1 --oneline` and show the output so the user can confirm the result.
+
+#### If temp file
+
+- Create a path with `mktemp -t pr-description` (with `.md` suffix) and write the full message (subject + blank line + body, same form used for the commit case) to it via the `Write` tool.
+- Report the absolute path back to the user along with a ready-to-run command, e.g. `git commit -F /tmp/pr-description.XXXXXX.md`.
+
+#### If the user picks "Other" or declines
+
+Do nothing further; the markdown block from Step 5 is already on screen for them to copy.
+

--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Claude Code statusLine
+# Format: cwd (branch) [tsh:cluster] model ctx:X% period:Y% t:Z%|ink/outk
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd')
+model=$(echo "$input" | jq -r '.model.display_name // ""' | grep -oiE 'sonnet|opus|haiku|claude' | head -1 | tr '[:upper:]' '[:lower:]')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+five_hr=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+resets_at=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+total_in=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+total_out=$(echo "$input" | jq -r '.context_window.total_output_tokens // empty')
+
+# Compute elapsed% of the 5-hour rate-limit window from resets_at (epoch seconds)
+rate_elapsed=""
+if [ -n "$resets_at" ]; then
+  now=$(date +%s)
+  window=18000  # 5 * 3600
+  secs_until=$(( resets_at - now ))
+  if [ "$secs_until" -lt 0 ]; then secs_until=0; fi
+  if [ "$secs_until" -gt "$window" ]; then secs_until=$window; fi
+  elapsed_pct=$(( (window - secs_until) * 100 / window ))
+  rate_elapsed="$elapsed_pct"
+fi
+
+# Get git branch for the current working directory
+branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
+if [ -n "$branch" ]; then
+  branch_str=$(printf ' \033[00;35m(%s)\033[00m' "$branch")
+else
+  branch_str=""
+fi
+
+# Build context string: model + ctx:X% [period:Y%]
+# cyan segment: ctx:X% and optional period:Y%
+cyan_parts=""
+if [ -n "$used" ]; then
+  cyan_parts=$(printf 'ctx:%.0f%%' "$used")
+fi
+if [ -n "$rate_elapsed" ]; then
+  if [ -n "$cyan_parts" ]; then
+    cyan_parts=$(printf '%s period:%d%%' "$cyan_parts" "$rate_elapsed")
+  else
+    cyan_parts=$(printf 'period:%d%%' "$rate_elapsed")
+  fi
+fi
+
+if [ -n "$cyan_parts" ]; then
+  ctx_str=$(printf '\033[00;33m%s\033[00m \033[00;36m%s\033[00m' "$model" "$cyan_parts")
+else
+  ctx_str=$(printf '\033[00;33m%s\033[00m' "$model")
+fi
+
+# cyan token segment: t:[five_hr%|]ink/outk
+if [ -n "$total_in" ] && [ -n "$total_out" ]; then
+  in_k=$(printf '%.0f' "$(echo "$total_in / 1000" | bc -l)")
+  out_k=$(printf '%.0f' "$(echo "$total_out / 1000" | bc -l)")
+  if [ -n "$five_hr" ]; then
+    ctx_str=$(printf '%s \033[00;36mt:%.0f%%|%sk/%sk\033[00m' "$ctx_str" "$five_hr" "$in_k" "$out_k")
+  else
+    ctx_str=$(printf '%s \033[00;36mt:%sk/%sk\033[00m' "$ctx_str" "$in_k" "$out_k")
+  fi
+fi
+
+# Get active tsh cluster
+tsh_cluster=$(grep '^cluster:' "$HOME/.tsh/profile.yaml" 2>/dev/null | head -1 | awk '{print $2}')
+if [ -n "$tsh_cluster" ]; then
+  tsh_str=$(printf ' \033[00;32m[tsh:%s]\033[00m' "$tsh_cluster")
+else
+  tsh_str=""
+fi
+
+home_dir="$HOME"
+short_cwd="${cwd/#$home_dir/\~}"
+printf '\033[01;34m%s\033[00m%s%s\n%s' "$short_cwd" "$branch_str" "$tsh_str" "$ctx_str"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 ## Script options
 stowOptions="-t $HOME --ignore setup -R -v"
-tools=("git" "zsh" "tmux" "nvim")
+tools=("git" "zsh" "tmux" "nvim" "claude")
 configTools=("nvim")
 
 ## Check for flags


### PR DESCRIPTION
### Description

Initial commit introducing a new `claude/` stow package that brings the user's Claude Code configuration (global `CLAUDE.md`, `settings.json`, and skills) under dotfiles management. Updates root `.gitignore` to negate the user's global `.claude/` ignore so the package can be tracked in this repo.

---
**Stack**:
- #54 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*