### PR TITLE
bugfix(): fix nvim EMFILE errors and add misc git/zsh config

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -28,5 +28,9 @@
 	autocorrect = 1
 [pull]
   rebase = true
+[rebase]
+  autoStash = true
+[init]
+	defaultBranch = main
 [commit]
   gpgsign = true

--- a/nvim/nvim/lua/plugins/lsp.lua
+++ b/nvim/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,15 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = function(_, opts)
+      opts.servers = opts.servers or {}
+      opts.servers["*"] = vim.tbl_deep_extend("force", opts.servers["*"] or {}, {
+        capabilities = {
+          workspace = {
+            didChangeWatchedFiles = { dynamicRegistration = false },
+          },
+        },
+      })
+    end,
+  },
+}

--- a/zsh/.zsh/env
+++ b/zsh/.zsh/env
@@ -170,7 +170,8 @@ if [[ $DISTRO == "darwin" ]]; then
     export PATH="$PATH:/opt/homebrew/bin"
     export PATH="$PATH:/usr/local/opt/coreutils/libexec/gnubin"
     export MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"
-    ulimit -n 10240
+    # FD soft limit is raised in ~/.zshenv (applies to all zsh invocations,
+    # not just interactive shells).
 fi
 
 

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,0 +1,16 @@
+# Sourced for ALL zsh invocations (login, interactive, non-interactive, scripts).
+# Anything here applies to subshells launched by GUI apps (Cursor's embedded nvim,
+# git editors, etc.) — not just interactive terminals where .zshrc runs.
+
+# Raise the per-process FD soft limit. macOS launchd defaults to 256, which is
+# trivially exhausted by Neovim plugins that spawn many subprocesses
+# (gitsigns -> git, conform/lint formatters, LSP), producing
+# `EMFILE: too many open files` from vim/_core/system.lua.
+# Only raise — never lower — so this composes correctly with the
+# limit.maxfiles LaunchDaemon (which sets soft=65536) and any other tool
+# that may already have set a higher limit.
+_cur_nofile=$(ulimit -Sn)
+if [ "$_cur_nofile" != "unlimited" ] && [ "$_cur_nofile" -lt 65536 ]; then
+    ulimit -Sn 65536 2>/dev/null
+fi
+unset _cur_nofile


### PR DESCRIPTION
### Description
- Fixes Neovim `EMFILE: too many open files` (raised from `vim/_core/system.lua`, observed via gitsigns spawning git workers; also affects LSP, conform, and nvim-lint). Addressed in two complementary places:
- `nvim/nvim/lua/plugins/lsp.lua` (new): disables LSP `workspace/didChangeWatchedFiles` dynamic registration via `opts.servers["*"].capabilities`. Stops Neovim from registering libuv `fs_event_start` watchers per workspace directory, which is the primary FD sink in large repos.
- `zsh/.zshenv` (new): raises the FD soft limit to 65536 for **all** zsh invocations, including non-interactive subshells (Cursor's embedded nvim, `git commit` editors, scripts). Previously the existing `ulimit -n 10240` lived in `zsh/.zsh/env`, which is only sourced from `~/.zshrc` — and `.zshrc` early-returns for non-interactive shells, so subprocess-launched nvim inherited the macOS launchd default of 256. The new file is "raise only, never lower," so it composes with a system-wide `limit.maxfiles` LaunchDaemon if one is installed.
- `zsh/.zsh/env`: removes the now-redundant `ulimit -n 10240` and points readers to `~/.zshenv`.
- `git/.gitconfig`: adds `rebase.autoStash = true` so `git pull --rebase` no longer aborts when the working tree has uncommitted changes, and `init.defaultBranch = main` so newly-created repos default to `main`.

---
**Stack**:
- #55 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*