### PR TITLE
feat(git,claude): work-devbox git safe.directory + gate claude skill dirs

### DIFF
--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -40,8 +40,11 @@
     ],
     "defaultMode": "auto",
     "additionalDirectories": [
+{{- if eq .class "work-devbox" }}
       "/home/coder/lwcode/services/.claude/skills",
-      "/home/coder/lwcode/services/vulnerability/.claude/skills"
+      "/home/coder/lwcode/services/vulnerability/.claude/skills",
+      "/home/coder/lwcode/services/vulnerability/vuln-feeds-manager/.claude/skills"
+{{- end }}
     ]
   },
   "statusLine": {

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -42,5 +42,9 @@
 [commit]
 	gpgsign = true
 {{- end }}
+{{ if eq .class "work-devbox" -}}
+[safe]
+	directory = /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
+{{ end -}}
 [include]
 	path = ~/.gitconfig_local


### PR DESCRIPTION
- git: add [safe] directory for the linuxbrew homebrew-core tap, gated to
class work-devbox (only that machine has linuxbrew at /home/linuxbrew).
- claude: template settings.json so the lwcode skill additionalDirectories
are populated only on work-devbox (empty array elsewhere), and add the
vuln-feeds-manager skills dir.

Excludes the tui:fullscreen toggle and the model-key reorder from the loose
main working tree (kept machine-local / cosmetic, respectively).

---
**Stack**:
- #70
- #69
- #68
- #67 ⬅
- #66
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*