### PR TITLE
feat(chezmoi): pin the source directory to ~/.dotfiles

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -48,6 +48,11 @@
 {{-   $coderHost = promptStringOnce . "coderHost" "coder ssh host for sleep/wake hooks (blank if none)" "" -}}
 {{- end -}}
 
+{{- /* Keep the chezmoi source at ~/.dotfiles on every machine (vs the default
+       ~/.local/share/chezmoi). The first `chezmoi init` still needs --source to
+       clone there; persisting it here makes every later bare command use it. */ -}}
+sourceDir = {{ (joinPath .chezmoi.homeDir ".dotfiles") | quote }}
+
 [data]
     environment = {{ $env | quote }}
     class = {{ $class | quote }}

--- a/home/executable_personalize
+++ b/home/executable_personalize
@@ -16,7 +16,7 @@ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 # dependency, and it works before the migration lands on the default branch).
 # install.sh also runs the base-package chezmoiscript and deploys the helper
 # scripts this bootstrap calls below.
-DOTFILES_SRC="${DOTFILES_SRC:-$HOME/.local/share/chezmoi}"
+DOTFILES_SRC="${DOTFILES_SRC:-$HOME/.dotfiles}"
 if [ -x "$DOTFILES_SRC/install.sh" ]; then
     "$DOTFILES_SRC/install.sh" --env work --class work-devbox
 else

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,12 @@
 #     sh -c "$(curl -fsLS https://raw.githubusercontent.com/Serubin/dotfiles/main/install.sh)"
 #
 #   From a local clone:
-#     git clone https://github.com/Serubin/dotfiles.git && dotfiles/install.sh
+#     git clone https://github.com/Serubin/dotfiles.git ~/.dotfiles && ~/.dotfiles/install.sh
 #
-# Installs chezmoi if needed, then runs `chezmoi init --apply`. When invoked from
-# inside a checkout of this repo, that checkout is used as the chezmoi source;
-# otherwise the repo is cloned from GitHub. chezmoi then prompts once for the
+# Installs chezmoi if needed, then runs `chezmoi init --apply`. The chezmoi source
+# directory is ~/.dotfiles (pinned via `sourceDir` in the config): run this from a
+# ~/.dotfiles checkout to use it in place, otherwise the repo is cloned from GitHub
+# into ~/.dotfiles. chezmoi then prompts once for the
 # machine environment/class + your git identity, clears any legacy GNU Stow
 # symlinks, installs packages for your OS, and writes the managed files into $HOME.
 #
@@ -91,6 +92,6 @@ if [ -n "$here" ] && [ -f "${here}/.chezmoiroot" ]; then
     echo "==> chezmoi init --apply (local source: ${here})"
     exec chezmoi init --apply ${init_flags} --source="${here}"
 else
-    echo "==> chezmoi init --apply ${GITHUB_REPO}"
-    exec chezmoi init --apply ${init_flags} "${GITHUB_REPO}"
+    echo "==> chezmoi init --apply --source ~/.dotfiles ${GITHUB_REPO}"
+    exec chezmoi init --apply ${init_flags} --source="${HOME}/.dotfiles" "${GITHUB_REPO}"
 fi


### PR DESCRIPTION
Move chezmoi's source dir off the default ~/.local/share/chezmoi to ~/.dotfiles
on every machine (the familiar path, and where the repo already lives).

- .chezmoi.toml.tmpl: set top-level sourceDir = ~/.dotfiles so every bare
`chezmoi` command uses it after the first init.
- install.sh: the remote-clone path now clones into ~/.dotfiles (--source); the
local path already honors the ~/.dotfiles checkout you run it from. Header
comment updated to match.
- personalize: DOTFILES_SRC default -> ~/.dotfiles.

Verified with chezmoi v2.71: the config template renders valid TOML with
sourceDir set, and `chezmoi init` clones the repo into the --source directory
(then the persisted sourceDir takes over for later commands).

---
**Stack**:
- #70
- #69 ⬅
- #68
- #67
- #66
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*