### PR TITLE
perf(zsh): speed up prompt render; add zsh benchmark script

### DIFF
--- a/home/dot_zsh/README.md
+++ b/home/dot_zsh/README.md
@@ -4,8 +4,11 @@
 
 | Metric | Time |
 |---|---|
-| Shell startup | ~60ms |
-| Prompt render (in git repo) | ~0.5ms |
+| Shell startup | ~80ms |
+| Prompt render (in git repo) | ~2ms |
+
+Startup is dominated by eager zinit plugin loading; prompt render is mostly the
+gitstatus query. Re-measure anytime with `scripts/bench-zsh.sh`.
 
 ## Structure
 

--- a/home/dot_zsh/prompt/prompt-theme
+++ b/home/dot_zsh/prompt/prompt-theme
@@ -36,12 +36,6 @@ function pre_cmd() {
 
     # ZSH - So simple!
     print -P $preprompt_format
-
-
-    # iTerm Touch Bar
-    # TODO @Solomon: Remove this, touch bars are deprecated
-    local iterm_message=$(git rev-parse --abbrev-ref HEAD 2> /dev/null; [[ $? -ne 0 ]] && echo "No Repo")
-    it2setkeylabel set status $iterm_message 2> /dev/null
 }
 
 # ZSH

--- a/scripts/bench-zsh.sh
+++ b/scripts/bench-zsh.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Benchmark zsh interactive startup and prompt-render time for these dotfiles.
+#
+#   scripts/bench-zsh.sh [startup_runs] [prompt_runs]
+#
+# Startup = `zsh -i -c exit` (sources ~/.zsh/* + loads zinit plugins), warmed.
+#           Uses hyperfine if installed, otherwise a zsh timing loop.
+# Prompt  = the precmd chain, timed under a pseudo-tty so gitstatus's background
+#           daemon is live, run inside a git repo, with a per-component breakdown.
+set -euo pipefail
+
+startup_runs="${1:-30}"
+prompt_runs="${2:-200}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+
+echo "== zsh startup (zsh -i -c exit, warmed) =="
+if command -v hyperfine >/dev/null 2>&1; then
+    hyperfine --warmup 5 --min-runs "$startup_runs" -N 'zsh -i -c exit'
+else
+    zsh -fc "
+        zmodload zsh/datetime
+        repeat 5 { zsh -i -c exit 2>/dev/null }          # warmup
+        integer n=$startup_runs
+        float sum=0 min=1e9 max=0 d
+        for i in {1..\$n}; do
+            s=\$EPOCHREALTIME; zsh -i -c exit 2>/dev/null; e=\$EPOCHREALTIME
+            d=\$(( (e-s)*1000 )); (( sum+=d )); (( d<min )) && min=d; (( d>max )) && max=d
+        done
+        printf '  min=%.1f  mean=%.1f  max=%.1f ms  (n=%d)\n' \$min \$((sum/n)) \$max \$n
+    "
+fi
+
+echo
+echo "== zsh prompt render (pty; gitstatus live; cwd=$repo_root) =="
+# The prompt uses gitstatus, whose daemon needs job control — so run interactive
+# zsh under a pseudo-tty via `script` (BSD and util-linux arg orders differ).
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+cat > "$tmp" <<PROMPTEOF
+zmodload zsh/datetime
+cd $repo_root
+prompt_precmd >/dev/null 2>&1                             # warm gitstatus + caches
+tb() { local n=$prompt_runs s e; s=\$EPOCHREALTIME; repeat \$n { eval "\$1" }; e=\$EPOCHREALTIME; printf '  %-22s %.3f ms\n' "\$2" \$(( (e-s)/n*1000.0 )); }
+tb 'gitstatus_query PROMPT >/dev/null 2>&1' 'gitstatus_query'
+tb 'git_stat >/dev/null 2>&1'               'git_stat'
+tb 'pre_cmd >/dev/null 2>&1'                'pre_cmd'
+tb 'prompt_precmd >/dev/null 2>&1'          'prompt_precmd (full)'
+PROMPTEOF
+
+if script --version 2>/dev/null | grep -qi util-linux; then
+    script -qec "zsh -ic 'source $tmp'" /dev/null
+else
+    script -q /dev/null zsh -ic "source $tmp"
+fi


### PR DESCRIPTION
pre_cmd forked a subshell and ran 'git rev-parse' on every prompt to set a
deprecated iTerm Touch Bar label (already TODO'd for removal). Removing it drops
prompt render from ~37ms to ~2ms; gitstatus itself is ~1ms.

- prompt-theme: remove the deprecated iTerm touch-bar block
- scripts/bench-zsh.sh: benchmark startup (hyperfine or zsh loop) + prompt render
  (per-component, under a pty so gitstatus's daemon is live)

commit-id:a55a6dfc

---
**Stack**:
- #84
- #83
- #82
- #81
- #80
- #79
- #78
- #77
- #76
- #75
- #74 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*