### PR TITLE
feat(chezmoi): add personal/work environment + class machine targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Or drive chezmoi directly without the wrapper:
 sh -c "$(curl -fsLS get.chezmoi.io)" && chezmoi init --apply Serubin/dotfiles
 ```
 
-`chezmoi init` prompts once for your git name/email/signingkey (press Enter to
-accept defaults), clones the plugin managers, installs packages for your OS, and
-writes the managed files into `$HOME`.
+`chezmoi init` prompts once for the machine environment/class (see
+[Machine targeting](#machine-targeting)) and your git name/email/signingkey
+(press Enter to accept defaults), clones the plugin managers, installs packages
+for your OS, and writes the managed files into `$HOME`.
 
 ### Migrating an existing machine from the old GNU Stow setup
 
@@ -56,6 +57,83 @@ You can also run it manually beforehand: [`scripts/uninstall-stow.sh`](scripts/u
 
 Package installs use `sudo` on Linux.
 
+## Machine targeting
+
+Every machine resolves two facts at `chezmoi init`, persisted in the local config
+(`~/.config/chezmoi/chezmoi.toml`) and used to gate config, scripts, and packages:
+
+- **`environment`** — the trust boundary, **validated** to `personal` or `work`.
+  The axis behind personal-only vs work-only gating.
+- **`class`** — a free-form role tag, **not validated**. Defaults to a value
+  derived from `environment` + OS, but you can override it with any string.
+
+The four default classes are the cross-product of `environment` and OS:
+
+|              | macOS            | Linux              |
+|--------------|------------------|--------------------|
+| **personal** | `personal-mac`   | `personal-server`  |
+| **work**     | `work-mac`       | `work-devbox`      |
+
+Custom classes (e.g. `homelab`, `work-ci`) are allowed — they just won't match the
+default-class gates, so add your own gate for them.
+
+### Setting it
+
+`chezmoi init` prompts once (press Enter to accept the derived class default). To
+answer non-interactively — scripted installs, CI, `curl | sh`:
+
+```bash
+DOTFILES_ENV=work chezmoi init --apply                          # environment only
+DOTFILES_ENV=work DOTFILES_CLASS=work-ci chezmoi init --apply   # custom class
+./install.sh --env work                                         # bootstrap wrapper
+./install.sh --env work --class work-ci                         # env + custom class
+```
+
+`install.sh` also accepts `--env`/`--class` as `--env=work`, and a bare
+`personal`/`work` positional still works as an `--env` shorthand.
+
+To change a machine later, edit `[data]` in `~/.config/chezmoi/chezmoi.toml`
+(`environment` / `class`) and `chezmoi apply`, or re-init. Both values are exported
+into your shell as `$DOTFILES_ENV` / `$DOTFILES_CLASS` (via `~/.zsh/zz-env`), so
+scripts and interactive config can branch on them.
+
+> **Existing machines:** a machine initialized before this feature has no
+> `environment`/`class` in its config. Run `chezmoi init` once (git identity is
+> remembered; you'll only be asked the new prompts) to populate them before the
+> next `chezmoi apply`.
+
+### Feature matrix
+
+Hand-maintained — keep in sync with the gating logic.
+
+| Feature | personal-mac | personal-server | work-mac | work-devbox |
+|---|:---:|:---:|:---:|:---:|
+| Core: zsh, git, tmux, Neovim | ✅ | ✅ | ✅ | ✅ |
+| Homebrew base packages | ✅ | — | ✅ | — |
+| yabai + skhd (config + install) | ✅ | — | ✅ | — |
+| `~/.local/bin` on PATH | ✅ | ✅ | ✅ | ✅ |
+| Per-class packages (`run_once_after_21`) | — | — | opt-in | opt-in |
+| `example-work-mac` script | — | — | ✅ | — |
+| `example-work-devbox` script | — | — | — | ✅ |
+
+### Adding a class-gated file or script
+
+Drop the file in the chezmoi source (e.g. `home/dot_local/bin/executable_foo`
+→ `~/.local/bin/foo`), then gate it in [`home/.chezmoiignore`](home/.chezmoiignore)
+at whichever level fits — patterns match target paths and can branch on any
+`[data]` value:
+
+```gotemplate
+{{ if ne .chezmoi.os "darwin" }}.config/yabai{{ end }}    # by OS  (any mac)
+{{ if ne .environment "work" }}.local/bin/vpn{{ end }}    # by environment
+{{ if ne .class "work-mac" }}.local/bin/foo{{ end }}      # by exact class tag
+```
+
+For per-machine *shell* config, add it to
+[`home/dot_zsh/zz-env.tmpl`](home/dot_zsh/zz-env.tmpl) (which branches on `.class`)
+rather than ignore-gating a sourced file: `.chezmoiignore` never removes an
+already-applied file, so a reclassified machine would keep sourcing a stale one.
+
 ## Day-to-day workflow
 
 chezmoi manages **copies**, not symlinks — editing `~/.zshrc` directly does *not*
@@ -79,6 +157,7 @@ chezmoi update               # git pull the source + apply
 | tmux | `~/.tmux.conf` | 256-color, TPM plugins, session restore |
 | Neovim | `~/.config/nvim/` | Lua config with lazy.nvim |
 | Claude Code | `~/.claude/` (curated) | CLAUDE.md, settings.json, statusline, skills, plugin config |
+| yabai + skhd | `~/.config/{yabai,skhd}` | macOS tiling WM + hotkey daemon (macs only) |
 
 ## Repository layout
 
@@ -86,16 +165,18 @@ chezmoi update               # git pull the source + apply
 .dotfiles/
 ├── .chezmoiroot                      # → home   (chezmoi source root)
 ├── home/
-│   ├── .chezmoi.toml.tmpl            # init prompts (git identity)
+│   ├── .chezmoi.toml.tmpl            # init prompts (environment/class + git identity)
 │   ├── .chezmoiignore                # runtime/secret paths chezmoi must not manage
 │   ├── .chezmoiexternal.toml.tmpl    # zinit, tpm, gitstatus (cloned & auto-updated)
 │   ├── .chezmoiscripts/
 │   │   ├── run_once_before_10-uninstall-stow.sh
-│   │   └── run_once_after_20-install-packages.sh.tmpl
+│   │   ├── run_once_after_20-install-packages.sh.tmpl
+│   │   └── run_once_after_21-install-env-packages.sh.tmpl  # per-class packages
 │   ├── dot_gitconfig.tmpl
 │   ├── dot_gitignore_global
 │   ├── dot_zshenv  dot_zshrc
-│   ├── dot_zsh/                      # 00-os 01-brew executable_02-zinit alias env function promptrc prompt/
+│   ├── dot_zsh/                      # 00-os 01-brew executable_02-zinit alias env function promptrc zz-env prompt/
+│   ├── dot_local/bin/               # → ~/.local/bin (on PATH); class-gated scripts
 │   ├── dot_tmux.conf
 │   ├── create_dot_custom             # ~/.custom (created once, never overwritten)
 │   ├── dot_config/nvim/
@@ -117,8 +198,11 @@ chezmoi update               # git pull the source + apply
   the managers:* zinit auto-installs its plugins on first interactive shell; for
   tmux run `prefix + I` once.
 - **Package installs.** `run_once_after_20-install-packages.sh.tmpl` installs
-  packages per-OS (Homebrew / apt). It re-runs only if its rendered content
-  changes.
+  base packages per-OS (Homebrew / apt); `run_once_after_21-install-env-packages`
+  adds per-class packages. Each re-runs only if its rendered content changes.
+- **Machine targeting.** `environment` (personal/work) and `class` are set at init
+  and gate templates, `.chezmoiignore`, and the package scripts — see
+  [Machine targeting](#machine-targeting).
 
 ## Tool details
 
@@ -127,7 +211,8 @@ chezmoi update               # git pull the source + apply
 - Aliases: `g s` (status), `g l` (pretty graph log), `g ap` (add -p), `g co`
   (checkout), `g br` (branch), plus `lg`, `ll`, `lm`, `su`, `reorder`, `contrib`.
 - Identity (name/email/signingkey) is templated and prompted once on
-  `chezmoi init` (press Enter to accept the defaults).
+  `chezmoi init`. No name or address is hardcoded in the repo, so fill them in when
+  prompted (values persist afterward).
 - **GPG commit signing** is enabled automatically when you provide a signingkey at
   init (`[commit] gpgsign = true`); leave the signingkey blank to keep it off.
 - `pull.rebase = true`, `rebase.autoStash = true`.

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,10 +1,50 @@
 {{- /* Rendered once on `chezmoi init` to create the chezmoi config.
-       Prompts for git identity so the public repo stays portable (work machine
-       can use a different email). Press Enter to accept the defaults; note that a
-       blank signingkey leaves commit signing disabled. */ -}}
-{{- $name := promptStringOnce . "git.name" "git user.name" "Solomon" -}}
+
+       Resolves two machine facts and prompts for git identity, then persists
+       everything under [data]. Press Enter to accept a default; a blank
+       signingkey leaves commit signing disabled.
+
+       - environment: the trust boundary. Validated to personal|work.
+       - class: a free-form role tag (personal-mac, work-devbox, homelab, ...).
+         Defaults to a value derived from environment + OS; NOT validated, so any
+         custom string is allowed. Templates + .chezmoiignore gate on .class.
+
+       Non-interactive override (scripted/CI installs, no TTY):
+         DOTFILES_ENV=work DOTFILES_CLASS=work-ci chezmoi init --apply
+       To change later: edit ~/.config/chezmoi/chezmoi.toml [data], or re-init. */ -}}
+
+{{- /* environment: validated trust boundary. */ -}}
+{{- $env := env "DOTFILES_ENV" -}}
+{{- if not $env -}}
+{{-   $env = promptChoiceOnce . "environment" "environment [personal|work]" (list "personal" "work") "personal" -}}
+{{- end -}}
+{{- if not (has $env (list "personal" "work")) -}}
+{{-   fail (printf "invalid environment %q (want personal|work)" $env) -}}
+{{- end -}}
+
+{{- /* class: free-form role tag. Default = derived <env>-<mac|server|devbox>. */ -}}
+{{- $defaultClass := "" -}}
+{{- if eq .chezmoi.os "darwin" -}}
+{{-   $defaultClass = printf "%s-mac" $env -}}
+{{- else if eq .chezmoi.os "linux" -}}
+{{-   $defaultClass = ternary "work-devbox" "personal-server" (eq $env "work") -}}
+{{- else -}}
+{{-   $defaultClass = printf "%s-%s" $env .chezmoi.os -}}
+{{- end -}}
+{{- $class := env "DOTFILES_CLASS" -}}
+{{- if not $class -}}
+{{-   $class = promptStringOnce . "class" "machine class (free-form; Enter for default)" $defaultClass -}}
+{{- end -}}
+
+{{- /* git identity: prompted once with no hardcoded defaults, so the public repo
+       carries no personal/work name or address. Values persist after first init. */ -}}
+{{- $name := promptStringOnce . "git.name" "git user.name" "" -}}
 {{- $email := promptStringOnce . "git.email" "git user.email" "" -}}
 {{- $signingkey := promptStringOnce . "git.signingkey" "git signingkey (blank to disable commit signing)" "" -}}
+
+[data]
+    environment = {{ $env | quote }}
+    class = {{ $class | quote }}
 
 [data.git]
     name = {{ $name | quote }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -27,3 +27,23 @@
 # (.zsh/README.md would otherwise be sourced by .zshrc's `~/.zsh/*` loop.)
 .zsh/README.md
 .config/nvim/README.md
+
+# ----- machine-class gating (see README "Machine targeting" + feature matrix) -----
+# Gate by OS (.chezmoi.os), environment (.environment), or class (.class). Patterns
+# match TARGET paths. NOTE: never glob a path that would swallow a .chezmoiexternal
+# target (.zsh/zinit, .zsh/gitstatus, .tmux/plugins/tpm) — that suppresses its clone.
+
+# yabai + skhd are macOS window-manager configs — keep on ANY mac, skip elsewhere.
+{{ if ne .chezmoi.os "darwin" }}
+.config/yabai
+.config/skhd
+{{ end }}
+
+# Class-specific example scripts (replace with your own). A custom class (e.g.
+# homelab) matches neither, so both are ignored — add your own class gate for it.
+{{ if ne .class "work-mac" }}
+.local/bin/example-work-mac
+{{ end }}
+{{ if ne .class "work-devbox" }}
+.local/bin/example-work-devbox
+{{ end }}

--- a/home/.chezmoiscripts/run_once_after_20-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_20-install-packages.sh.tmpl
@@ -16,6 +16,10 @@ if ! command -v brew >/dev/null 2>&1; then
 fi
 brew install git zsh tmux neovim atool gsed coreutils
 brew install romkatv/gitstatus/gitstatus
+# Window management (all macs). After install, start them once with
+# `yabai --start-service` and `skhd --start-service`; some yabai features also
+# require SIP to be partially disabled (manual, out of scope here).
+brew install koekeishiya/formulae/yabai koekeishiya/formulae/skhd
 
 {{ else if eq .chezmoi.os "linux" -}}
 {{   $id := .chezmoi.osRelease.id -}}

--- a/home/.chezmoiscripts/run_once_after_21-install-env-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_21-install-env-packages.sh.tmpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Per-class package installs, kept SEPARATE from 20-install-packages so that
+# switching class (or editing these lists) re-runs only this script — never the
+# base install, which on Debian rebuilds Neovim from source. run_once_ re-runs
+# whenever this file's RENDERED content changes.
+set -euo pipefail
+
+{{ if eq .class "work-mac" -}}
+# ===== work-mac =====
+# TODO: work-mac-only tooling, e.g.:
+#   brew install <corp-tool>
+{{ else if eq .class "work-devbox" -}}
+# ===== work-devbox =====
+# TODO: work-devbox-only tooling, e.g.:
+#   sudo apt-get install -y <corp-tool>
+{{ else -}}
+# No class-specific packages for class={{ .class }}.
+{{ end -}}

--- a/home/dot_local/bin/executable_example-work-devbox
+++ b/home/dot_local/bin/executable_example-work-devbox
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# EXAMPLE — delete or replace with a real script.
+#
+# Deployed to ~/.local/bin ONLY on the `work-devbox` class. Gating lives in
+# home/.chezmoiignore:  {{ if ne .class "work-devbox" }}.local/bin/example-work-devbox{{ end }}
+# ~/.local/bin is on PATH (see home/dot_zshenv), so this is runnable as
+# `example-work-devbox` on a work devbox and absent everywhere else.
+set -euo pipefail
+echo "example-work-devbox: hello from environment=${DOTFILES_ENV:-?} class=${DOTFILES_CLASS:-?}"

--- a/home/dot_local/bin/executable_example-work-mac
+++ b/home/dot_local/bin/executable_example-work-mac
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# EXAMPLE — delete or replace with a real script.
+#
+# Deployed to ~/.local/bin ONLY on the `work-mac` class. Gating lives in
+# home/.chezmoiignore:  {{ if ne .class "work-mac" }}.local/bin/example-work-mac{{ end }}
+# ~/.local/bin is on PATH (see home/dot_zshenv), so this is runnable as
+# `example-work-mac` on a work mac and absent everywhere else.
+set -euo pipefail
+echo "example-work-mac: hello from environment=${DOTFILES_ENV:-?} class=${DOTFILES_CLASS:-?}"

--- a/home/dot_zsh/zz-env.tmpl
+++ b/home/dot_zsh/zz-env.tmpl
@@ -1,0 +1,22 @@
+# Per-machine shell config, resolved at apply time by chezmoi (no runtime
+# detection). Sourced LAST by ~/.zshrc's `~/.zsh/*` loop (the `zz-` prefix sorts
+# after alias/env/function/promptrc), so it can override anything set earlier.
+#
+# This is machine-ROLE config committed to the repo. For machine-LOCAL, unmanaged
+# overrides and secrets use ~/.custom instead (sourced afterward, not tracked).
+#
+# environment={{ .environment }}  class={{ .class }}
+export DOTFILES_ENV={{ .environment | quote }}
+export DOTFILES_CLASS={{ .class | quote }}
+
+{{ if eq .class "work-mac" -}}
+# ===== work-mac =====
+{{ else if eq .class "work-devbox" -}}
+# ===== work-devbox =====
+{{ else if eq .class "personal-mac" -}}
+# ===== personal-mac =====
+{{ else if eq .class "personal-server" -}}
+# ===== personal-server =====
+{{ else -}}
+# ===== {{ .class }} =====  (custom or other class)
+{{ end -}}

--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -14,3 +14,11 @@ if [ "$_cur_nofile" != "unlimited" ] && [ "$_cur_nofile" -lt 65536 ]; then
     ulimit -Sn 65536 2>/dev/null
 fi
 unset _cur_nofile
+
+# Put ~/.local/bin on PATH for ALL zsh invocations (interactive, scripts, and
+# GUI-launched tools) — chezmoi installs machine-specific executables there.
+# Appended (not prepended) so user scripts can never shadow system binaries.
+case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) export PATH="$PATH:$HOME/.local/bin" ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -10,14 +10,61 @@
 #
 # Installs chezmoi if needed, then runs `chezmoi init --apply`. When invoked from
 # inside a checkout of this repo, that checkout is used as the chezmoi source;
-# otherwise the repo is cloned from GitHub. chezmoi then prompts once for your git
-# identity, clears any legacy GNU Stow symlinks, installs packages for your OS,
-# and writes the managed files into $HOME.
+# otherwise the repo is cloned from GitHub. chezmoi then prompts once for the
+# machine environment/class + your git identity, clears any legacy GNU Stow
+# symlinks, installs packages for your OS, and writes the managed files into $HOME.
+#
+# Machine targeting: set the environment and/or class non-interactively via flags
+# or env vars (both just seed $DOTFILES_ENV / $DOTFILES_CLASS, which the chezmoi
+# config template reads):
+#     dotfiles/install.sh --env work
+#     dotfiles/install.sh --env work --class work-ci
+#     DOTFILES_ENV=work DOTFILES_CLASS=work-ci sh -c "$(curl -fsLS .../install.sh)"
 #
 # Override the repo with DOTFILES_REPO=owner/name.
 set -eu
 
 GITHUB_REPO="${DOTFILES_REPO:-Serubin/dotfiles}"
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: install.sh [--env personal|work] [--class NAME] [personal|work]
+  --env    machine environment (personal|work); seeds $DOTFILES_ENV
+  --class  machine class (free-form, e.g. work-ci); seeds $DOTFILES_CLASS
+USAGE
+}
+
+# Flags (and a backward-compatible bare `personal|work`) just seed $DOTFILES_ENV /
+# $DOTFILES_CLASS, which the chezmoi config template reads; a flag overrides a
+# value already present in the environment.
+DOTFILES_ENV="${DOTFILES_ENV:-}"
+DOTFILES_CLASS="${DOTFILES_CLASS:-}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --env)     [ $# -ge 2 ] || { echo "--env needs a value" >&2; exit 2; }; DOTFILES_ENV="$2"; shift 2 ;;
+        --env=*)   DOTFILES_ENV="${1#*=}"; shift ;;
+        --class)   [ $# -ge 2 ] || { echo "--class needs a value" >&2; exit 2; }; DOTFILES_CLASS="$2"; shift 2 ;;
+        --class=*) DOTFILES_CLASS="${1#*=}"; shift ;;
+        personal|work) DOTFILES_ENV="$1"; shift ;;   # backward-compat shorthand
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+# Validate environment (the config template validates too, but fail early with a
+# clear message). Class is intentionally free-form and left unvalidated.
+case "$DOTFILES_ENV" in
+    ""|personal|work) ;;
+    *) echo "invalid --env '$DOTFILES_ENV' (want personal|work)" >&2; exit 2 ;;
+esac
+if [ -n "$DOTFILES_ENV" ];   then export DOTFILES_ENV;   fi
+if [ -n "$DOTFILES_CLASS" ]; then export DOTFILES_CLASS; fi
+
+# Non-interactive installs (curl | sh pipe, CI) have no TTY: fall back to chezmoi's
+# prompt defaults so init can't hang on the git-identity prompts (which fire on a
+# fresh init even when env/class are supplied). Env/class still win in the template.
+init_flags=""
+[ -t 0 ] || init_flags="--promptDefaults"
 
 # 1. Ensure chezmoi is available.
 if ! command -v chezmoi >/dev/null 2>&1; then
@@ -42,8 +89,8 @@ esac
 
 if [ -n "$here" ] && [ -f "${here}/.chezmoiroot" ]; then
     echo "==> chezmoi init --apply (local source: ${here})"
-    exec chezmoi init --apply --source="${here}"
+    exec chezmoi init --apply ${init_flags} --source="${here}"
 else
     echo "==> chezmoi init --apply ${GITHUB_REPO}"
-    exec chezmoi init --apply "${GITHUB_REPO}"
+    exec chezmoi init --apply ${init_flags} "${GITHUB_REPO}"
 fi


### PR DESCRIPTION
Resolve a two-value machine model at `chezmoi init`, persisted in the local
config:

- environment (personal|work): validated trust boundary behind personal/work
  gating.
- class: free-form role tag, default derived as <env>-<mac|server|devbox>,
  overridable to any string (e.g. homelab, work-ci) via $DOTFILES_CLASS.

Git identity (name/email) is prompted at init with no hardcoded defaults, so the
public repo carries no personal/work address.

Gate config/scripts/packages on these values:
- .chezmoiignore: yabai+skhd on any mac; example-work-mac / example-work-devbox
  gated by exact class tag.
- dot_zsh/zz-env.tmpl: exports DOTFILES_ENV/DOTFILES_CLASS, branches per class
  (sources last so it can override base config).
- dot_local/bin -> ~/.local/bin (added to PATH in dot_zshenv, appended so it
  can't shadow system binaries), with class-gated example scripts.
- run_once_after_20: install yabai+skhd on macs.
- run_once_after_21 (new): per-class packages, split out so switching class
  doesn't re-trigger the base install (Debian Neovim source build).
- install.sh: --env / --class flags (with a bare personal|work shorthand) that
  seed $DOTFILES_ENV / $DOTFILES_CLASS; --promptDefaults on no-TTY installs.

Document machine targeting, a feature matrix, and a class-gating recipe in the
README.

commit-id:f81afeaa

---
**Stack**:
- #84
- #83
- #82
- #81
- #80
- #79
- #78
- #77
- #76
- #75 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*