### PR TITLE
feat(sleepwatcher): add work-mac sleep/wake hooks for Coder connections

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -42,9 +42,16 @@
 {{- $email := promptStringOnce . "git.email" "git user.email" "" -}}
 {{- $signingkey := promptStringOnce . "git.signingkey" "git signingkey (blank to disable commit signing)" "" -}}
 
+{{- /* coderHost: coder ssh host for the work-mac sleepwatcher hooks; blank if N/A. */ -}}
+{{- $coderHost := env "DOTFILES_CODER_HOST" -}}
+{{- if not $coderHost -}}
+{{-   $coderHost = promptStringOnce . "coderHost" "coder ssh host for sleep/wake hooks (blank if none)" "" -}}
+{{- end -}}
+
 [data]
     environment = {{ $env | quote }}
     class = {{ $class | quote }}
+    coderHost = {{ $coderHost | quote }}
 
 [data.git]
     name = {{ $name | quote }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -47,3 +47,9 @@
 {{ if ne .class "work-devbox" }}
 .local/bin/example-work-devbox
 {{ end }}
+
+# sleepwatcher sleep/wake feature (Coder iTerm2/tmux + fwd hygiene): work-mac only.
+{{ if ne .class "work-mac" }}
+.config/sleepwatcher
+Library/LaunchAgents/net.serubin.sleepwatcher.plist
+{{ end }}

--- a/home/.chezmoiscripts/run_once_after_22-work-mac-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_22-work-mac-packages.sh.tmpl
@@ -1,0 +1,14 @@
+#!/bin/bash
+{{ if eq .class "work-mac" -}}
+# work-mac packages. sleepwatcher drives the ~/.config/sleepwatcher sleep/wake
+# hooks (agent: net.serubin.sleepwatcher). Isolated from the main installer so a
+# tap-trust hiccup there can't block it, and vice versa.
+set -euo pipefail
+if command -v brew >/dev/null 2>&1; then
+    brew install sleepwatcher
+else
+    echo "Homebrew not found — install sleepwatcher manually for net.serubin.sleepwatcher." >&2
+fi
+{{- else -}}
+exit 0
+{{- end }}

--- a/home/.chezmoiscripts/run_onchange_after_30-reload-sleepwatcher.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_30-reload-sleepwatcher.sh.tmpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+{{ if eq .class "work-mac" -}}
+# Reload the chezmoi-managed sleepwatcher agent when its plist changes; migrate off
+# brew's service and the old ~/.wakeup/~/.sleep layout. Idempotent.
+# plist-hash: {{ include "Library/LaunchAgents/net.serubin.sleepwatcher.plist.tmpl" | sha256sum }}
+set -euo pipefail
+export PATH="/opt/homebrew/bin:$PATH"
+label="net.serubin.sleepwatcher"
+plist="$HOME/Library/LaunchAgents/${label}.plist"
+domain="gui/$(id -u)"
+
+brew services stop sleepwatcher 2>/dev/null || true          # drop brew's competing agent
+rm -f "$HOME/.wakeup" "$HOME/.sleep" "$HOME/.wakeup-tmux.log" # remove pre-relocation files
+
+launchctl bootout "${domain}/${label}" 2>/dev/null || true
+launchctl bootstrap "${domain}" "${plist}"
+echo "sleepwatcher agent ${label} loaded."
+{{- else -}}
+exit 0
+{{- end }}

--- a/home/Library/LaunchAgents/net.serubin.sleepwatcher.plist.tmpl
+++ b/home/Library/LaunchAgents/net.serubin.sleepwatcher.plist.tmpl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>net.serubin.sleepwatcher</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{ output "brew" "--prefix" | trim }}/opt/sleepwatcher/sbin/sleepwatcher</string>
+		<string>-V</string>
+		<string>-s</string>
+		<string>{{ .chezmoi.homeDir }}/.config/sleepwatcher/sleep</string>
+		<string>-w</string>
+		<string>{{ .chezmoi.homeDir }}/.config/sleepwatcher/wakeup</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist>

--- a/home/dot_config/sleepwatcher/executable_sleep.tmpl
+++ b/home/dot_config/sleepwatcher/executable_sleep.tmpl
@@ -1,0 +1,31 @@
+#!/bin/bash
+# sleepwatcher sleep hook (work-mac). Tear down the `fwd` SOCKS tunnel to the Coder
+# workspace so it can't linger as a half-open zombie across sleep. fwd runs in the
+# foreground of a terminal tab with no supervisor, so it will NOT auto-restart —
+# relaunch it yourself after wake. Narrow match: only the fwd supervisor and its
+# `ssh -T -D` SOCKS child; the tmux -CC ssh (ssh -tt) is untouched.
+# Set SLEEP_DRY_RUN=1 to log targets without killing (for testing).
+# Managed by chezmoi: home/dot_config/sleepwatcher/. coderHost from machine-local data.
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH
+log="$HOME/.config/sleepwatcher/events.log"
+host='{{ .coderHost | replace "." "\\." }}'   # coder ssh host, dots regex-escaped
+
+ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
+targets=$( { pgrep -f "fwd ${host}"; pgrep -f "ssh -T -D [0-9]+ ${host}"; } | sort -un)
+
+{
+  echo "=== sleep $ts ==="
+  if [ -n "$targets" ]; then
+    echo "fwd targets:"
+    for p in $targets; do ps -o pid,etime,command= -p "$p" 2>/dev/null | sed 's/^/  /'; done
+  else
+    echo "no fwd/SOCKS ssh present (nothing to kill)"
+  fi
+} >> "$log" 2>&1
+
+if [ -n "$targets" ] && [ -z "$SLEEP_DRY_RUN" ]; then
+  echo "$targets" | xargs kill 2>>"$log"
+  echo "  killed." >> "$log"
+elif [ -n "$targets" ]; then
+  echo "  DRY_RUN: not killing." >> "$log"
+fi

--- a/home/dot_config/sleepwatcher/executable_wakeup.tmpl
+++ b/home/dot_config/sleepwatcher/executable_wakeup.tmpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+# sleepwatcher wake hook (work-mac). Reap the iTerm2 tmux -CC ssh that Coder's
+# roaming tunnel keeps alive across sleep, so iTerm2 releases the gateway and
+# offers a clean reconnect. Narrow match => the SOCKS `fwd` ssh is untouched; the
+# remote session is never killed (tmux new -A reattaches; continuum has state).
+# Set WAKEUP_DRY_RUN=1 to log the target without killing (for testing).
+# Managed by chezmoi: home/dot_config/sleepwatcher/. coderHost from machine-local data.
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH
+log="$HOME/.config/sleepwatcher/events.log"
+host='{{ .coderHost | replace "." "\\." }}'   # coder ssh host, dots regex-escaped
+
+# keep the log bounded
+if [ -f "$log" ] && [ "$(wc -c < "$log")" -gt 100000 ]; then
+  tail -n 200 "$log" > "$log.tmp" && mv "$log.tmp" "$log"
+fi
+
+ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
+targets=$(pgrep -f "ssh -tt ${host}.*tmux-devel\.sh")
+
+{
+  echo "=== wake $ts ==="
+  if [ -n "$targets" ]; then
+    echo "target tmux -CC ssh:"
+    for p in $targets; do ps -o pid,etime,command= -p "$p" 2>/dev/null | sed 's/^/  /'; done
+  else
+    echo "no tmux-devel.sh ssh present (nothing to reap)"
+  fi
+} >> "$log" 2>&1
+
+if [ -n "$targets" ] && [ -z "$WAKEUP_DRY_RUN" ]; then
+  echo "$targets" | xargs kill 2>>"$log"
+  echo "  reaped." >> "$log"
+elif [ -n "$targets" ]; then
+  echo "  DRY_RUN: not killing." >> "$log"
+fi


### PR DESCRIPTION
Self-contained, work-mac-gated sleepwatcher feature under
~/.config/sleepwatcher, driven by a chezmoi-managed LaunchAgent
(net.serubin.sleepwatcher) that replaces the brew service:

- wakeup: reap the iTerm2 tmux -CC ssh that Coder's roaming tunnel keeps
  alive across sleep, so iTerm2 releases its gateway and offers a clean
  reconnect (fixes the "already attached" zombie after a lid-close).
- sleep: tear down the fwd SOCKS tunnel so it can't linger half-open.

The Coder host is injected from a machine-local `coderHost` data var, so
it never enters this public repo. Deployment is gated to class "work-mac"
via .chezmoiignore; the sleepwatcher install lives in its own run_once
script so a tap-trust hiccup in the main installer can't block it.

commit-id:a418dd89

---
**Stack**:
- #84
- #83
- #82
- #81
- #80
- #79
- #78
- #77
- #76 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*