### PR TITLE
feat(docker): usable interactive Debian test harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,38 @@
 FROM debian:latest
 
-# Tools needed to bootstrap chezmoi + clone externals. The chezmoi run_once
-# package script installs everything else (zsh, tmux, neovim, ...).
+# Tools needed to bootstrap chezmoi + clone externals, plus a few conveniences
+# that make the container behave like a real terminal for interactive testing:
+#   procps  -> working `ps`/`top`
+#   locales -> UTF-8 (C.UTF-8) so the zsh prompt renders correctly
+#   less    -> a pager for git/etc.
+#   zsh     -> land in a login shell (also what chezmoi's package script installs)
+#   neovim  -> pre-installed so run_once_after_20 SKIPS the slow from-source build
+#              (Debian's nvim is older, but the harness tests dotfiles config, not
+#              nvim itself; drop it here to exercise the source-build path instead)
+# The chezmoi run_once package script installs everything else (tmux, gh, ...).
 RUN apt-get update && \
-    apt-get install -y curl git sudo ca-certificates && \
+    apt-get install -y --no-install-recommends \
+        curl git sudo ca-certificates procps locales less zsh neovim && \
     rm -rf /var/lib/apt/lists/*
 
-# Install chezmoi into /usr/local/bin
+# A non-root user with passwordless sudo — matches a real machine and actually
+# exercises the sudo package-install path (as root every `sudo` is a silent
+# no-op). Login shell is zsh so plain `docker compose exec debian zsh` works too.
+ARG USER=dev
+RUN useradd --create-home --shell /usr/bin/zsh "$USER" && \
+    echo "$USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/"$USER" && \
+    chmod 0440 /etc/sudoers.d/"$USER"
+
+# Install chezmoi into /usr/local/bin (on PATH for every user).
 RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
 
-WORKDIR /workspace
+# One-command bootstrap: apply the mounted source, then drop into a login zsh.
+COPY scripts/docker-test.sh /usr/local/bin/dotfiles-test
+RUN chmod +x /usr/local/bin/dotfiles-test
+
+USER dev
+WORKDIR /home/dev
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=xterm-256color SHELL=/usr/bin/zsh
+
+# Keep the container alive so you can `docker compose exec` into it repeatedly.
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -182,8 +182,10 @@ chezmoi update               # git pull the source + apply
 │   ├── dot_config/git/               # → ~/.config/git/{config.tmpl,ignore} (XDG git config)
 │   ├── dot_config/nvim/
 │   └── dot_claude/                   # CURATED: CLAUDE.md, settings.json, statusline, skills/, plugins/*.json
-├── scripts/uninstall-stow.sh         # remove legacy Stow symlinks (manual)
-├── Dockerfile  docker-compose.yml    # Debian test harness
+├── scripts/
+│   ├── uninstall-stow.sh             # remove legacy Stow symlinks (manual)
+│   └── docker-test.sh                # → `dotfiles-test` in the container: apply + login zsh
+├── Dockerfile  docker-compose.yml    # Debian test harness (non-root sudo user)
 ├── LICENSE  .spr.yml  README.md
 ```
 
@@ -295,12 +297,27 @@ credentials) is left untouched.
 
 ## Docker testing (Debian)
 
+Spins up a Debian container as a **non-root user with passwordless sudo** (so the
+`sudo` package installs are actually exercised) with the repo mounted read-only at
+`/workspace`.
+
 ```bash
 docker compose up -d --build
-docker compose exec debian bash
-# inside the container:
-chezmoi init --source=/workspace --apply
+docker compose exec debian dotfiles-test   # bootstrap (prompts) + drop into login zsh
+# or, without applying:
+docker compose exec debian zsh
 ```
+
+`dotfiles-test` runs `chezmoi init --apply` against the mounted source and drops
+you into the configured login zsh; it's idempotent, so re-running is a fast
+re-apply. Seed the env/class prompts non-interactively via the commented
+`environment:` block in `docker-compose.yml` (or `DOTFILES_ENV=… DOTFILES_CLASS=…
+docker compose exec debian dotfiles-test`).
+
+> **Neovim caveat:** the image pre-installs Debian's `nvim` so the harness skips
+> the multi-minute from-source build (`run_once_before_20`). That apt build is
+> older than what a real machine gets; it's fine for testing the dotfiles config,
+> but to exercise the source-build path, drop `neovim` from the `Dockerfile`.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,19 @@ services:
   debian:
     build: .
     volumes:
-      - .:/workspace
-    entrypoint: ["tail", "-f", "/dev/null"]
-    command: "/bin/bash"
-    # Inside the container: chezmoi init --source=/workspace --apply
-    stdin_open: true # docker run -i
+      # Live source, read-only: edit on the host, re-apply in the container.
+      # chezmoi never writes into the source (its state lives in
+      # ~/.config/chezmoi), so read-only is safe and keeps the container from
+      # mutating your working tree.
+      - .:/workspace:ro
+    working_dir: /home/dev
+    # Seed the init prompts for a non-interactive apply (git identity then falls
+    # back to chezmoi's prompt defaults). Uncomment to skip the env/class prompts.
+    # environment:
+    #   DOTFILES_ENV: personal
+    #   DOTFILES_CLASS: personal-server
+    stdin_open: true # docker compose run/exec -i
     tty: true
+    # Bootstrap + drop into a login zsh:  docker compose exec debian dotfiles-test
+    # Plain shell without applying:        docker compose exec debian zsh
+    # The image CMD (sleep infinity) keeps the container alive for `exec`.

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Interactive test-harness entrypoint, baked into the Debian image as
+# `dotfiles-test` (see Dockerfile). Runs the real chezmoi bootstrap against the
+# source mounted at /workspace, then drops you into a login zsh so you can
+# actually USE the configured environment (prompt, aliases, tmux, ...).
+#
+# First run prompts for environment/class/git identity, exactly like a real
+# machine. Seed them non-interactively via DOTFILES_ENV / DOTFILES_CLASS (see the
+# commented `environment:` block in docker-compose.yml); when seeded with no TTY,
+# chezmoi's --promptDefaults fills the remaining (git identity) prompts.
+set -euo pipefail
+
+SOURCE="${DOTFILES_SOURCE:-/workspace}"
+
+# No TTY (e.g. `docker compose exec -T`, CI) can't answer the git-identity
+# prompts, which fire on a fresh init even when env/class are seeded — fall back
+# to chezmoi's prompt defaults so init can't hang. Mirrors install.sh.
+init_flags=""
+[ -t 0 ] || init_flags="--promptDefaults"
+
+# chezmoi reads /workspace/.chezmoiroot and uses /workspace/home as the source.
+# Idempotent: re-running won't re-trigger run_once installs (e.g. the Neovim
+# build), so this doubles as a fast re-apply.
+echo "==> chezmoi init --apply (source: ${SOURCE})"
+chezmoi init --apply ${init_flags} --source="${SOURCE}"
+
+echo "==> entering login zsh (exit to return to the container shell)"
+exec zsh -l


### PR DESCRIPTION
- run as a non-root user with passwordless sudo (exercises the real sudo
  package-install path; as root every sudo was a silent no-op)
- pre-install nvim/zsh + procps/locales/less so the harness behaves like a
  real terminal and skips the multi-minute Neovim source build
- fix the entrypoint (was `tail -f /dev/null /bin/bash`, which streamed the
  bash binary into `docker compose logs`); keep the container alive via CMD
- add `dotfiles-test` (scripts/docker-test.sh): one-command chezmoi apply +
  login zsh, with --promptDefaults fallback when no TTY
- mount the source read-only; document the new flow in README

commit-id:9072d3bd

---
**Stack**:
- #84
- #83
- #82
- #81
- #80
- #79 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*