### PR TITLE
feat(tmux): mouse/titles, save-on-detach, devbox -CC helper scripts

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -48,6 +48,14 @@
 .local/bin/example-work-devbox
 {{ end }}
 
+# tmux -CC (iTerm2 control-mode) devbox helpers: the periodic-save cron target
+# and the stale-client-clearing connect helper. work-devbox only — the mac side
+# of this workflow is the sleepwatcher feature below.
+{{ if ne .class "work-devbox" }}
+.local/bin/tmux-periodic-save.sh
+.local/bin/tmux-devel.sh
+{{ end }}
+
 # sleepwatcher sleep/wake feature (Coder iTerm2/tmux + fwd hygiene): work-mac only.
 {{ if ne .class "work-mac" }}
 .config/sleepwatcher

--- a/home/.chezmoiscripts/run_onchange_after_40-tmux-devbox-cron.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_40-tmux-devbox-cron.sh.tmpl
@@ -1,0 +1,21 @@
+#!/bin/bash
+{{ if eq .class "work-devbox" -}}
+# Install the attach-independent tmux-resurrect periodic-save cron (every 5 min),
+# the devbox replacement for tmux-continuum's timer: continuum's save rides
+# status-line #() interpolation, which tmux does NOT evaluate under iTerm2 control
+# mode (-CC), so its timer never fires in our workflow. run_onchange_ re-runs only
+# when this file's rendered content changes. Idempotent — the line is de-duped by
+# its marker comment, and other crontab entries are preserved.
+set -euo pipefail
+
+if ! command -v crontab >/dev/null 2>&1; then
+    echo "crontab not found — skipping tmux-periodic-save cron install." >&2
+    exit 0
+fi
+
+line="*/5 * * * * $HOME/.local/bin/tmux-periodic-save.sh >/dev/null 2>&1 # tmux-periodic-save"
+( crontab -l 2>/dev/null | grep -vF '# tmux-periodic-save'; echo "$line" ) | crontab -
+echo "tmux-periodic-save cron installed (*/5)."
+{{- else -}}
+exit 0
+{{- end }}

--- a/home/dot_local/bin/executable_tmux-devel.sh
+++ b/home/dot_local/bin/executable_tmux-devel.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Connect to the `devel` tmux session for the iTerm2 -CC integration.
+# Free `devel` of any client already attached BEFORE we attach. Safe by timing:
+# at connect time any pre-existing client is the stale one. Kill the PROCESS
+# (not `-D` soft-detach) so a wedged/paused post-lid-close client actually goes;
+# the client-detached hook still fires a save. Managed by chezmoi
+# (source: home/dot_local/bin/executable_tmux-devel.sh).
+tmux list-clients -t devel -F '#{client_pid}' 2>/dev/null | xargs -r kill 2>/dev/null
+exec tmux -CC new -A -D -s devel

--- a/home/dot_local/bin/executable_tmux-periodic-save.sh
+++ b/home/dot_local/bin/executable_tmux-periodic-save.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Attach-independent periodic snapshot of tmux state via tmux-resurrect.
+# WHY: tmux-continuum's periodic save rides status-line #() interpolation, which
+# tmux does NOT evaluate under iTerm2 control mode (-CC) -- so its timer never
+# fires in our workflow. cron runs this every few minutes regardless of attach
+# state. Managed by chezmoi (source: home/dot_local/bin/executable_tmux-periodic-save.sh);
+# the */5 cron entry is installed by .chezmoiscripts/run_onchange_after_40-tmux-devbox-cron.
+set -uo pipefail
+SAVE="$HOME/.tmux/plugins/tmux-resurrect/scripts/save.sh"
+RESURRECT_DIR="$HOME/.local/share/tmux/resurrect"
+LOCK="/tmp/tmux-periodic-save.lock"
+MIN_SERVER_UPTIME=120   # skip until past continuum's restore-on-start window
+KEEP=200                # snapshots to retain
+[ -x "$SAVE" ] || exit 0
+exec 9>"$LOCK" || exit 0
+flock -n 9 || exit 0
+pid="$(tmux display-message -p '#{pid}' 2>/dev/null)" || exit 0
+[ -n "$pid" ] || exit 0
+up="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')"
+[ -n "$up" ] && [ "$up" -ge "$MIN_SERVER_UPTIME" ] || exit 0
+"$SAVE" quiet >/dev/null 2>&1 || exit 0
+# Prune oldest snapshots (sorted by filename timestamp), never the `last` target.
+last_path="$RESURRECT_DIR/$(readlink "$RESURRECT_DIR/last" 2>/dev/null)"
+ls -1 "$RESURRECT_DIR"/tmux_resurrect_*.txt 2>/dev/null | sort -r | tail -n +"$((KEEP + 1))" \
+  | grep -vxF "$last_path" | xargs -r rm -f
+# Success regardless of prune outcome (empty prune makes grep exit 1 under pipefail).
+exit 0

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -12,6 +12,8 @@ set-option -g pane-active-border 'fg=blue'
 set -g default-terminal "screen-256color"
 # Don't clear when exiting vim or man pages
 set-window-option -g alternate-screen off
+set-option -g set-titles on
+set -g mouse on
 
 ############################################################################
 # Indexing (irssi style)
@@ -46,6 +48,13 @@ set -g status-left ' #{session_name} | '
 ############################################################################
 set -g @continuum-restore 'on'
 set -g @continuum-save-interval '5'
+set -g @resurrect-capture-pane-contents 'on'
+
+# Continuum's auto-save is driven by `#()` interpolation in status-right, which
+# only fires while a client is attached. Save explicitly on detach so a fresh
+# snapshot is written before the status loop dies — otherwise reboots restore
+# whatever the last status-interval save happened to catch (often very stale).
+set-hook -g client-detached 'run-shell -b "~/.tmux/plugins/tmux-resurrect/scripts/save.sh quiet"'
 
 ############################################################################
 # Prefix highlighting

--- a/home/dot_zsh/alias.tmpl
+++ b/home/dot_zsh/alias.tmpl
@@ -47,4 +47,16 @@ alias py="python"
 
 alias extract="aunpack"
 
+# Manually snapshot tmux session state via tmux-resurrect (on top of the cron
+# periodic save + client-detached hook). Unconditional — unlike the cron wrapper.
+alias tmux-save='$HOME/.tmux/plugins/tmux-resurrect/scripts/save.sh quiet && echo "✓ tmux session saved"'
+
 bindkey '^R' history-incremental-search-backward
+
+function tabname() {
+  if [ -z "$TMUX" ] ; then
+    printf "\e]1;%s\a" "$*"
+  else
+    tmux rename-window "$*"
+  fi
+}

--- a/home/dot_zsh/env.tmpl
+++ b/home/dot_zsh/env.tmpl
@@ -115,6 +115,14 @@ bindkey "\eOF" end-of-line
 bindkey "\e[H" beginning-of-line
 bindkey "\e[F" end-of-line
 
+# Eat tmux focus-in/out so iTerm2 focus-follows-mouse hovering doesn't ring the
+# bell at the prompt. tmux-sensible enables focus-events; without these binds,
+# the unbound \e[I / \e[O escapes trip zsh's beep setopt.
+_tmux_focus_noop() { }
+zle -N _tmux_focus_noop
+bindkey "\e[I" _tmux_focus_noop
+bindkey "\e[O" _tmux_focus_noop
+
 # Case-sensitive globbing (used in pathname expansion)
 
 setopt case_glob


### PR DESCRIPTION
Port the tmux workflow tweaks and the previously-loose ~/.local/bin
scripts into chezmoi.

- dot_tmux.conf: enable set-titles + mouse; capture pane contents on
  resurrect; save on client-detached so -CC/reboot restores aren't stale.
- zsh alias/env: tmux-save alias, tabname(), and no-op binds that eat
  tmux focus-in/out escapes so iTerm2 focus-follows-mouse won't beep.
- dot_local/bin: executable_tmux-periodic-save.sh (cron target) and
  executable_tmux-devel.sh (-CC connect helper), gated to work-devbox.
- run_onchange_after_40-tmux-devbox-cron: install the */5 periodic-save
  cron (continuum's timer never fires under iTerm2 -CC).

These were previously generated ad-hoc by ~/personalize; they are now
chezmoi-managed (source of truth moves into the repo).

commit-id:d9c7c0e0

---
**Stack**:
- #84
- #83
- #82
- #81
- #80 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*