### PR TITLE
fix(install): retry chezmoi apply once on transient failure

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,8 +90,17 @@ esac
 
 if [ -n "$here" ] && [ -f "${here}/.chezmoiroot" ]; then
     echo "==> chezmoi init --apply (local source: ${here})"
-    exec chezmoi init --apply ${init_flags} --source="${here}"
+    set -- chezmoi init --apply ${init_flags} --source="${here}"
 else
     echo "==> chezmoi init --apply --source ~/.dotfiles ${GITHUB_REPO}"
-    exec chezmoi init --apply ${init_flags} --source="${HOME}/.dotfiles" "${GITHUB_REPO}"
+    set -- chezmoi init --apply ${init_flags} --source="${HOME}/.dotfiles" "${GITHUB_REPO}"
+fi
+
+# git-repo externals (zinit/gitstatus/tpm) can flake on the first heavy
+# init --apply; retry once so a transient clone hiccup doesn't leave onboarding
+# half-done. The retry converges cheaply: cloned externals are cached, run_once
+# scripts are already recorded, and nothing re-installs.
+if ! "$@"; then
+    echo "==> first apply failed; retrying once (transient external clone?)..." >&2
+    "$@"
 fi


### PR DESCRIPTION
git-repo externals (zinit/gitstatus/tpm) can flake on the first heavy
`chezmoi init --apply` — the first new clone occasionally fails mid-init,
halting apply before the run_after scripts and the remaining externals.

Drop the `exec` so the invocation can be retried once. The retry converges
cheaply (already-cloned externals are cached, run_once scripts are recorded,
nothing reinstalls) and a genuine persistent error still surfaces on the
second failure via set -e.

commit-id:0b3e2584

---
**Stack**:
- #84 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*