### PR TITLE
feat(claude): keep tui:default in settings.json

### DIFF
--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -58,5 +58,6 @@
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark-daltonized",
   "verbose": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "tui": "default"
 }


### PR DESCRIPTION
The TUI preference was set live in ~/.claude/settings.json but absent from
the source template, so `chezmoi apply` would strip it. Pin "tui": "default"
in the template so it survives apply on every machine.

---
**Stack**:
- #89 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*