### PR TITLE
fix(zsh): stop appending Homebrew to the end of PATH

### DIFF
--- a/home/dot_zsh/01-brew.tmpl
+++ b/home/dot_zsh/01-brew.tmpl
@@ -1,3 +1,6 @@
 {{ if eq .chezmoi.os "darwin" -}}
-export PATH="$PATH:/opt/homebrew/bin"
+# Homebrew PATH now lives in ~/.zprofile: it must be prepended AFTER macOS's
+# /etc/zprofile runs path_helper (which reorders /usr/bin ahead of anything set
+# in ~/.zshenv/~/.zsh), and ABOVE ~/.zprofile's python.org framework prepends so
+# `python3` stays 3.10. ~/.zprofile is unmanaged (python.org-installer-owned).
 {{ end -}}

--- a/home/dot_zsh/env.tmpl
+++ b/home/dot_zsh/env.tmpl
@@ -174,7 +174,6 @@ export VISUAL=nvim # vim vim vim
 
 {{ if eq .chezmoi.os "darwin" -}}
 # fixes for osx
-export PATH="$PATH:/opt/homebrew/bin"
 export PATH="$PATH:/usr/local/opt/coreutils/libexec/gnubin"
 export MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"
 # FD soft limit is raised in ~/.zshenv (applies to all zsh invocations,


### PR DESCRIPTION
## Problem
`brew doctor` flagged that `/usr/bin` precedes `/opt/homebrew/bin` in `PATH`, so Apple's `git`, `openssl`, `jq`, `ruby`, `gem` shadowed Homebrew's. Root cause: two `export PATH="$PATH:/opt/homebrew/bin"` lines (`01-brew.tmpl` and `env.tmpl`) *appended* Homebrew to the end of `PATH`, and the duplicate put it in twice.

Appending from `~/.zsh` (sourced by `~/.zshrc`) can never beat `/usr/bin`: macOS `/etc/zprofile` runs `path_helper`, which reorders `/etc/paths` entries (`/usr/bin`) ahead of anything set earlier in the load order.

## Change
Removes both append lines. The Homebrew prepend now lives in `~/.zprofile`, above the python.org framework prepends:
- runs **after** `/etc/zprofile`'s `path_helper`, so it lands **ahead of** `/usr/bin`;
- stays **below** the framework prepends, so `python3` remains the python.org **3.10** framework (not Homebrew's linked `python@3.14`);
- also adds `/opt/homebrew/sbin` (clears the separate "sbin not in PATH" warning).

## ⚠️ Reproducibility note
The actual prepend lives in **unmanaged `~/.zprofile`** (python.org-installer-owned — the same file the framework prepends already live in), so it is **not** captured by this repo. A fresh `chezmoi` bootstrap must set up the Homebrew `PATH` prepend in `~/.zprofile` separately. Folding it into chezmoi is a possible follow-up.

## Verification
In a fresh login shell (simulated with a clean parent `PATH`):
- `/opt/homebrew/bin` + `sbin` precede `/usr/bin`; `git`/`openssl`/`jq`/`ruby`/`gem` resolve to Homebrew.
- `python3` unchanged → python.org 3.10 framework.
- No duplicate `/opt/homebrew/bin` entries; the `~/.zprofile` guard is idempotent for nested shells.
- `brew doctor`'s PATH-order and sbin warnings clear in a fresh login shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)