### PR TITLE
feat(zsh): Replace zsh-autosuggestions with deja

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,12 @@ to add or reorder config.
 
 **Plugins** (via [zinit](https://github.com/zdharma-continuum/zinit)):
 - `zsh-syntax-highlighting` — command highlighting
-- `zsh-autosuggestions` — fish-like suggestions
 - `zsh-jump-target` — quick directory jumping
 - `dircolors-solarized` — solarized color scheme for `ls`
+
+Inline suggestions come from [deja](https://github.com/Giammarco-Ferranti/deja)
+— predictive ghost-text autosuggestions (replaces `zsh-autosuggestions`).
+It's a Homebrew binary + daemon, initialized in `02-zinit`, not a zinit plugin.
 
 The prompt is a custom theme powered by
 [gitstatus](https://github.com/romkatv/gitstatus) for fast git status.

--- a/home/.chezmoiscripts/run_once_before_20-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_before_20-install-packages.sh.tmpl
@@ -28,6 +28,8 @@ brew install romkatv/gitstatus/gitstatus
 # `yabai --start-service` and `skhd --start-service`; some yabai features also
 # require SIP to be partially disabled (manual, out of scope here).
 brew install asmvik/formulae/yabai asmvik/formulae/skhd
+# deja: predictive shell autosuggestions (replaces zsh-autosuggestions).
+brew install Giammarco-Ferranti/deja/deja
 
 {{ else if eq .chezmoi.os "linux" -}}
 {{   $id := .chezmoi.osRelease.id -}}
@@ -82,7 +84,23 @@ else
     sudo apt-get update
     sudo apt-get install -y gh
 fi
+
+# deja: predictive shell autosuggestions (replaces zsh-autosuggestions). Homebrew
+# only, per the migration decision.
+if command -v brew >/dev/null 2>&1; then
+    brew install Giammarco-Ferranti/deja/deja
+else
+    echo "Homebrew not found — skipping deja; run 'brew install Giammarco-Ferranti/deja/deja' once brew is available." >&2
+fi
 {{   else -}}
 echo "Unsupported Linux distro: '{{ $id }}'. Install git zsh tmux atool neovim manually." >&2
 {{   end -}}
 {{ end -}}
+
+# One-time seed of deja's DB from our history. `deja import` is NOT idempotent
+# (it inserts rows blindly), so run it only when the DB doesn't exist yet. Our
+# HISTFILE is ~/.config/.histfile (see dot_zsh/env.tmpl) — NOT deja's default — so
+# point it there explicitly. Best-effort; never fail the apply.
+if command -v deja >/dev/null 2>&1 && [ ! -f "$HOME/.local/share/deja/deja.db" ]; then
+    deja import --file "$HOME/.config/.histfile" || true
+fi

--- a/home/dot_zsh/README.md
+++ b/home/dot_zsh/README.md
@@ -128,6 +128,13 @@ by `pre_cmd` to embed git info in the prompt.
 ## Plugins (zinit)
 
 - **zsh-syntax-highlighting** — real-time command highlighting
-- **zsh-autosuggestions** — fish-style autosuggestions
 - **zsh-jump-target** — quick cursor jumping (`^F`)
 - **dircolors-solarized** — solarized color scheme for `ls` (auto-selects `gdircolors` on macOS, `dircolors` on Linux)
+
+Inline suggestions come from **[deja](https://github.com/Giammarco-Ferranti/deja)**
+— predictive ghost-text autosuggestions replacing `zsh-autosuggestions`. It's a
+Homebrew binary + daemon (installed by `run_once_before_20-install-packages`),
+`eval`'d in `02-zinit`, so it's not a zinit-managed plugin. Right/End accept the
+full suggestion, Ctrl+Right accepts a word; its Tab-picker and `^X` toggle are
+disabled (via empty `DEJA_CYCLE_KEY`/`DEJA_TOGGLE_KEY`) to preserve completion and
+`^X^E`.

--- a/home/dot_zsh/executable_02-zinit.tmpl
+++ b/home/dot_zsh/executable_02-zinit.tmpl
@@ -4,7 +4,18 @@ ZINIT_HOME="${HOME}/.zsh/zinit"
 source "${ZINIT_HOME}/zinit.zsh"
 
 zinit light zsh-users/zsh-syntax-highlighting
-zinit light zsh-users/zsh-autosuggestions
+
+# deja: predictive ghost-text autosuggestions, replacing zsh-autosuggestions.
+# Binary installed via Homebrew (run_once_before_20-install-packages). deja wraps
+# ZLE widgets — Right/End accept the full suggestion, Ctrl+Right accepts a word
+# (the widgets autosuggestions also hooked) — and re-asserts on every precmd, so
+# load order is irrelevant. Disable the two default keybindings that would else
+# clobber ours each prompt: Tab (keep completion) and ^X (keep ^X^E, see env).
+if (( $+commands[deja] )); then
+    DEJA_CYCLE_KEY=''
+    DEJA_TOGGLE_KEY=''
+    eval "$(deja init zsh)"
+fi
 zinit ice pick"/dev/null" atload'ZSH_JUMP_TARGET_STYLE="fg=blue,bold,underline"; fpath+=(${ZINIT[PLUGINS_DIR]}/scfrazer---zsh-jump-target/functions); autoload -Uz jump-target; zle -N jump-target; bindkey "^F" jump-target'
 zinit light scfrazer/zsh-jump-target
 


### PR DESCRIPTION
Inline autosuggestions now come from [deja](https://github.com/Giammarco-Ferranti/deja)
instead of zsh-autosuggestions. deja predicts the next command from frecency
(frequency + recency), the current directory, and fuzzy matching, where
zsh-autosuggestions only prefix-matched raw history. Acceptance is unchanged:
Right/End take the full suggestion, Ctrl+Right takes a word.

## Implementation

deja is a Go binary + daemon, not a zsh plugin, so it's installed via its
Homebrew tap on both macOS and Linux (brew-if-present, non-fatal skip otherwise
on Debian) and initialized with `eval "$(deja init zsh)"` in `02-zinit`. Its
ghost-text and accept behavior works by wrapping the same ZLE widgets
zsh-autosuggestions hooked and re-asserting them every precmd, so its position
in the load order is irrelevant.

deja's two default keybindings are disabled (`DEJA_CYCLE_KEY` / `DEJA_TOGGLE_KEY`
set empty) so it doesn't steal Tab from completion or `^X` from `^X^E`
edit-command-line. History is seeded once from `~/.config/.histfile` — our
`HISTFILE`, not deja's default — via `deja import --file`, guarded on the DB not
already existing because `deja import` is not idempotent (it inserts rows
blindly).

## Verification

There's no CI for shell behavior, so verified by hand on this Mac after
`chezmoi apply`: deja 0.3.2 installed, 3455 history commands imported, and a
fresh interactive shell confirms `^X^E` still runs edit-command-line, Tab still
runs expand-or-complete, and deja's accept widget is registered and active.
